### PR TITLE
Issue 24: Add version checks for API fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM sonatype/nexus3:latest
+FROM sonatype/nexus3:3.10.0
 LABEL maintainer="Deven Phillips <deven.phillips@redhat.com>" \
       vendor="Red Hat" \
       description="Sonatype Nexus repository manager with Kubernetes/OpenShift Config plugin" \
       source="https://github.com/InfoSec812/nexus-kubernetes-openshift" \
       documentation="https://github.com/InfoSec812/nexus-kubernetes-openshift/blob/master/README.md"
-ARG PLUGIN_VERSION=0.2.6
+ARG PLUGIN_VERSION=0.2.7
 
 USER root
 ADD https://github.com/InfoSec812/nexus-kubernetes-openshift/releases/download/v${PLUGIN_VERSION}/nexus-openshift-plugin-${PLUGIN_VERSION}.jar /opt/sonatype/nexus/deploy/nexus-openshift-plugin.jar

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,7 +4,7 @@ LABEL maintainer="Deven Phillips <deven.phillips@redhat.com>" \
       description="Sonatype Nexus repository manager with Kubernetes/OpenShift Config plugin" \
       source="https://github.com/InfoSec812/nexus-kubernetes-openshift" \
       documentation="https://github.com/InfoSec812/nexus-kubernetes-openshift/blob/master/README.md"
-ARG PLUGIN_VERSION=0.2.6
+ARG PLUGIN_VERSION=0.2.7
 
 USER root
 ADD https://github.com/InfoSec812/nexus-kubernetes-openshift/releases/download/v${PLUGIN_VERSION}/nexus-openshift-plugin-${PLUGIN_VERSION}.jar /opt/sonatype/nexus/deploy/nexus-openshift-plugin.jar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes/OpenShift Provisioning Plugin For [Sonatype Nexus](https://www.sonatype.com/nexus-repository-sonatype)
 
-[![Build Status](https://travis-ci.com/InfoSec812/nexus-kubernetes-openshift.svg?branch=v0.2.6)](https://travis-ci.com/InfoSec812/nexus-kubernetes-openshift)
+[![Build Status](https://travis-ci.com/InfoSec812/nexus-kubernetes-openshift.svg?branch=v0.2.7)](https://travis-ci.com/InfoSec812/nexus-kubernetes-openshift)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0&metric=coverage)](https://sonarcloud.io/dashboard?id=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0&metric=bugs)](https://sonarcloud.io/dashboard?id=com.redhat.labs.nexus%3Anexus-openshift-plugin%3A3.0)

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>com.redhat.labs.nexus</groupId>
   <artifactId>nexus-openshift-plugin</artifactId>
-  <version>0.2.6-SNAPSHOT</version>
+  <version>0.2.7-SNAPSHOT</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <packaging>bundle</packaging>
   <description>Nexus Kubernetes/OpenShift Configuration Plugin</description>

--- a/src/main/groovy/com/redhat/labs/nexus/openshift/RepositoryConfigWatcher.groovy
+++ b/src/main/groovy/com/redhat/labs/nexus/openshift/RepositoryConfigWatcher.groovy
@@ -1,5 +1,7 @@
 package com.redhat.labs.nexus.openshift
 
+import groovy.transform.PackageScope
+
 /*-
  * #%L
  * com.redhat.labs.nexus:nexus-openshift-plugin
@@ -9,13 +11,13 @@ package com.redhat.labs.nexus.openshift
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * This Source Code may also be made available under the following Secondary
  * Licenses when the conditions for such availability set forth in the Eclipse
  * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
  * with the GNU Classpath Exception which is
  * available at https://www.gnu.org/software/classpath/license.html.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  * #L%
  */
@@ -24,6 +26,12 @@ import io.kubernetes.client.models.V1ConfigMap
 import org.apache.commons.collections.list.FixedSizeList
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.sonatype.nexus.common.app.ApplicationVersion
+import org.sonatype.nexus.common.app.VersionComparator
+
+import javax.inject.Inject
+import javax.inject.Named;
+import javax.inject.Singleton;
 import org.sonatype.nexus.blobstore.api.BlobStoreManager
 import org.sonatype.nexus.repository.manager.RepositoryManager
 import org.sonatype.nexus.repository.maven.LayoutPolicy
@@ -32,9 +40,25 @@ import org.sonatype.nexus.repository.storage.WritePolicy
 import org.sonatype.nexus.script.plugin.RepositoryApi
 import org.sonatype.nexus.script.plugin.internal.provisioning.RepositoryApiImpl
 
+import java.util.stream.Collectors
+
+@Named
 class RepositoryConfigWatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepositoryConfigWatcher.class)
+
+  @Inject
+  @PackageScope
+  RepositoryApi repositoryApi
+
+  @Inject
+  @PackageScope
+  RepositoryManager repositoryManager
+
+  @Inject
+  ApplicationVersion applicationVersion
+
+  VersionComparator versionComparator = new VersionComparator()
 
   // *** !!!WARNING!!! ***
   // The order of the fields in this map matches the order they must be in when passing them
@@ -42,33 +66,33 @@ class RepositoryConfigWatcher {
   // fields without serious consideration.
   private final def VALID_RECIPES = [
           'AptHosted'     : [
-                  description                : [type: 'String', required: false],
-                  pgpPrivateKey              : [type: 'String', required: false],
-                  pgpPassPhrase              : [type: 'String', required: false],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  distribution                : [type: 'String', required: false],
+                  pgpPrivateKey               : [type: 'String', required: false],
+                  pgpPassPhrase               : [type: 'String', required: false],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'AptProxy'      : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  distribution               : [type: 'String', required: false],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  distribution                : [type: 'String', required: false],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'BowerGroup'    : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'BowerHosted'   : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'BowerProxy'    : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  rewritePackageUrls         : [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  rewritePackageUrls          : [type: 'boolean', required: true, default: true]
           ],
           'DockerGroup'   : [
                   httpPort                    : [type: 'Integer', required: false],
@@ -79,145 +103,145 @@ class RepositoryConfigWatcher {
                   forceBasicAuth              : [type: 'boolean', required: true, default: true]
           ],
           'DockerHosted'  : [
-                  httpPort                   : [type: 'Integer', required: false],
-                  httpsPort                  : [type: 'Integer', required: false],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  v1Enabled                  : [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
-                  forceBasicAuth             : [type: 'boolean', required: true, default: true]
+                  httpPort                    : [type: 'Integer', required: false],
+                  httpsPort                   : [type: 'Integer', required: false],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  v1Enabled                   : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
+                  forceBasicAuth              : [type: 'boolean', required: true, default: true, version: '3.14']
           ],
           'DockerProxy'   : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  indexType                  : [type: 'String', required: true, default: 'REGISTRY'],
-                  indexUrl                   : [type: 'String', required: false, default: 'https://hub.docker.io/'],
-                  httpPort                   : [type: 'Integer', required: false],
-                  httpsPort                  : [type: 'Integer', required: false],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  v1Enabled                  : [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  indexType                   : [type: 'String', required: true, default: 'REGISTRY'],
+                  indexUrl                    : [type: 'String', required: false, default: 'https://hub.docker.io/'],
+                  httpPort                    : [type: 'Integer', required: false],
+                  httpsPort                   : [type: 'Integer', required: false],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  v1Enabled                   : [type: 'boolean', required: true, default: true]
           ],
           'GitLfsHosted'  : [
-                  blobStoreName              : [type: 'String'],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String'],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'GolangGroup'   : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'GolangHosted'  : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'GolangProxy'   : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'MavenGroup'    : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'MavenHosted'   : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  versionPolicy              : [type: 'VersionPolicy', required: true, default: VersionPolicy.RELEASE],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW_ONCE],
-                  layoutPolicy               : [type: 'LayoutPolicy', required: true, default: LayoutPolicy.STRICT]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  versionPolicy               : [type: 'VersionPolicy', required: true, default: VersionPolicy.RELEASE],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW_ONCE],
+                  layoutPolicy                : [type: 'LayoutPolicy', required: true, default: LayoutPolicy.STRICT]
           ],
           'MavenProxy'    : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  versionPolicy              : [type: 'VersionPolicy', required: true, default: VersionPolicy.RELEASE],
-                  layoutPolicy               : [type: 'LayoutPolicy', required: true, default: LayoutPolicy.STRICT]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  versionPolicy               : [type: 'VersionPolicy', required: true, default: VersionPolicy.RELEASE],
+                  layoutPolicy                : [type: 'LayoutPolicy', required: true, default: LayoutPolicy.STRICT]
           ],
           'NpmGroup'      : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'NpmHosted'     : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'NpmProxy'      : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'NugetGroup'    : [
-                  members      : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName: [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'NugetHosted'   : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'NugetProxy'    : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'PyPiGroup'     : [
                   members                     : [type: 'List<String>', required: true, default: ''],
                   blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'PyPiHosted'    : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'PyPiProxy'     : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'RawGroup'      : [
                   members                     : [type: 'List<String>', required: true, default: ''],
                   blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'RawHosted'     : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'RawProxy'      : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'RubygemsGroup' : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'RubygemsHosted': [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW]
           ],
           'RubygemsProxy' : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ],
           'YumGroup'      : [
-                  members                    : [type: 'List<String>', required: true, default: ''],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
+                  members                     : [type: 'List<String>', required: true, default: ''],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME]
           ],
           'YumHosted'     : [
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true],
-                  writePolicy                : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
-                  depth                      : [type: 'Integer', required: true, default: 0]
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true],
+                  writePolicy                 : [type: 'WritePolicy', required: true, default: WritePolicy.ALLOW],
+                  depth                       : [type: 'Integer', required: true, default: 0]
           ],
           'YumProxy'      : [
-                  remoteUrl                  : [type: 'String', required: true],
-                  blobStoreName              : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
-                  strictContentTypeValidation: [type: 'boolean', required: true, default: true]
+                  remoteUrl                   : [type: 'String', required: true],
+                  blobStoreName               : [type: 'String', required: true, default: BlobStoreManager.DEFAULT_BLOBSTORE_NAME],
+                  strictContentTypeValidation : [type: 'boolean', required: true, default: true]
           ]
   ]
 
@@ -226,10 +250,10 @@ class RepositoryConfigWatcher {
    * @param repository An instance of {@link RepositoryApi}
    * @param configMap A {@link V1ConfigMap} containing information about the Group
    */
-  void updateGroupMembers(RepositoryManager repoManager, V1ConfigMap configMap) {
-    def repo = repoManager.get(configMap.metadata.name)
+  void updateGroupMembers(V1ConfigMap configMap) {
+    def repo = repositoryManager.get(configMap.metadata.name)
     repo.configuration.attributes.group.memberNames = configMap.getData().get("members").split(',').toList().unique()
-    repoManager.update(repo.configuration)
+    repositoryManager.update(repo.configuration)
   }
 
   /**
@@ -240,20 +264,22 @@ class RepositoryConfigWatcher {
    * @param configMap A {@link V1ConfigMap} which SHOULD have the correct parameters for the indicated recipe
    * @throws Exception If there is an error provisioning the repository
    */
-  void createNewRepository(RepositoryApi repository, V1ConfigMap configMap) throws Exception {
+  void createNewRepository(V1ConfigMap configMap) throws Exception {
     String repositoryName = configMap.metadata.name
     LOG.info("Provisioning repository with name '{}'", repositoryName)
     def recipe = configMap.data.get("recipe") as String
     if (VALID_RECIPES.get(recipe) != null) {
       def fields = VALID_RECIPES[recipe]
 
+      def fieldCount = fields.entrySet().stream().filter(this.&filterVersionedFields).count()
+
       // The list of parameters MUST exactly match the required number of parameters for
       // the specified recipe or the dynamic method call later will not work.
-      def numberOfArguments = fields.size() + 1
+      def numberOfArguments = fieldCount + 1
       def parameters = FixedSizeList.decorate(Arrays.asList(new Object[numberOfArguments]))
       parameters.set(0, repositoryName)
       for (int x=1; x<numberOfArguments; x++) { parameters.set(x, null) }
-      fields.entrySet().eachWithIndex { item, i ->
+      fields.entrySet().stream().filter(this.&filterVersionedFields).eachWithIndex { item, i ->
         // Since repository name is the first argument to ALL recipes, skip the first argument when doing assignments
         def idx = i + 1
         def field = item.value
@@ -322,9 +348,30 @@ class RepositoryConfigWatcher {
         }
       }
       LOG.info('Method: {} - Parameters: {}', recipe, parameters)
-      repository."create${recipe}"(*parameters)
+      repositoryApi."create${recipe}"(*parameters)
     } else {
       LOG.warn("'${recipe}' is not a valid Nexus recipe")
     }
+  }
+
+  /**
+   * For fields which are only available from a certain version of Nexus, filter out fields which are
+   * not compatible with the running version of Nexus
+   * @param fieldEntry An {@link Map.Entry} containing a Key and Value
+   * @return {@code true} if the field is compatible with the current version of Nexus
+   */
+  @PackageScope
+  boolean filterVersionedFields(Map.Entry<String, Map> fieldEntry) {
+    if (fieldEntry.value?.version) {
+      def fieldVersion = fieldEntry.value.version
+      if (versionComparator.compare(fieldVersion, applicationVersion.version) <= 0) {
+        return true
+      } else {
+        return false
+      }
+    } else {
+      return true
+    }
+//    return (!fieldEntry.value.hasProperty('version') || versionComparator.compare(fieldEntry.value.version, applicationVersion.version) >= 0)
   }
 }

--- a/src/main/java/com/redhat/labs/nexus/openshift/BlobStoreConfigWatcher.java
+++ b/src/main/java/com/redhat/labs/nexus/openshift/BlobStoreConfigWatcher.java
@@ -25,21 +25,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.nexus.BlobStoreApi;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 /**
  * A watcher for BlobStore configurations for Nexus. This watcher will NEVER DELETE BLOBSTORES, ONLY CREATE
  */
-
+@Named
+@Singleton
 public class BlobStoreConfigWatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(BlobStoreConfigWatcher.class);
 
-  public void addBlobStore(V1ConfigMap configMap, BlobStoreApi manager) {
+  @Inject
+  BlobStoreApi blobStoreApi;
+
+  public void addBlobStore(V1ConfigMap configMap) {
     String blobStoreName = configMap.getMetadata().getName();
     LOG.info("Provisioning BlobStore named '{}'", blobStoreName);
     // If the blobStoreName is defined and the blobstore does not already exist
     if (blobStoreName != null) {
       // A new ConfigMap labelled as a BlobStore config has been detected. Create the new BlobStore
-      manager.createFileBlobStore(blobStoreName, String.format("/nexus-data/blobs/%s", blobStoreName));
+      blobStoreApi.createFileBlobStore(blobStoreName, String.format("/nexus-data/blobs/%s", blobStoreName));
     }
   }
 }

--- a/src/test/groovy/com/redhat/labs/nexus/openshift/BlobStoreConfigWatcherSpec.groovy
+++ b/src/test/groovy/com/redhat/labs/nexus/openshift/BlobStoreConfigWatcherSpec.groovy
@@ -32,9 +32,10 @@ class BlobStoreConfigWatcherSpec extends Specification {
       }
       def blobStoreApi = Mock(BlobStoreApi)
       def underTest = new BlobStoreConfigWatcher()
+      underTest.blobStoreApi = blobStoreApi
 
     when:
-      underTest.addBlobStore(configMap, blobStoreApi)
+      underTest.addBlobStore(configMap)
 
     then:
       1 * blobStoreApi.createFileBlobStore('testBlobStore', '/nexus-data/blobs/testBlobStore')

--- a/src/test/groovy/com/redhat/labs/nexus/openshift/OpenShiftConfigPluginSpec.groovy
+++ b/src/test/groovy/com/redhat/labs/nexus/openshift/OpenShiftConfigPluginSpec.groovy
@@ -44,12 +44,8 @@ class OpenShiftConfigPluginSpec extends Specification {
       def client = Mock(ApiClient)
       def api = Mock(CoreV1Api)
       def security = Mock(SecuritySystem)
-      def blobStoreManager = Mock(BlobStoreApi)
-      def repository = Mock(RepositoryApi)
       def secret = Mock(V1Secret)
       def underTest = new OpenShiftConfigPlugin()
-      underTest.blobStoreApi = blobStoreManager
-      underTest.repository = repository
       underTest.api = api
       underTest.client = client
       underTest.security = security
@@ -68,7 +64,6 @@ class OpenShiftConfigPluginSpec extends Specification {
   def "Successfully reads ConfigMaps and applies them"() {
     given:
       def api = Mock(CoreV1Api)
-      def security = Mock(SecuritySystem)
       def blobStoreConfigMapList = Mock(V1ConfigMapList)
       def repoStoreConfigMapList = Mock(V1ConfigMapList)
       def mockItem = Mock(V1ConfigMap) {
@@ -87,9 +82,7 @@ class OpenShiftConfigPluginSpec extends Specification {
       def mockBlobStoreConfigWatcher = Mock(BlobStoreConfigWatcher)
       underTest.repositoryConfigWatcher = mockRepoConfigWatcher
       underTest.blobStoreConfigWatcher = mockBlobStoreConfigWatcher
-      underTest.blobStoreApi = blobStoreApi
       underTest.blobStoreManager = blobStoreManager
-      underTest.repository = repository
       underTest.repositoryManager = repoManager
       underTest.api = api
       underTest.namespace = "testnamespace"
@@ -106,8 +99,8 @@ class OpenShiftConfigPluginSpec extends Specification {
       1 * repoManager.get(_) >> null
       4 * mockItem.getMetadata() >> mockMetaData
       4 * mockMetaData.getName() >> "itemName"
-      1 * mockBlobStoreConfigWatcher.addBlobStore(mockItem, blobStoreApi)
-      1 * mockRepoConfigWatcher.createNewRepository(repository, mockItem)
+      1 * mockBlobStoreConfigWatcher.addBlobStore(mockItem)
+      1 * mockRepoConfigWatcher.createNewRepository(mockItem)
   }
 
   def "configureFromCluster happy path"() {
@@ -169,13 +162,9 @@ class OpenShiftConfigPluginSpec extends Specification {
         getData() >> [recipe: 'MavenGroup']
       }
       def repositoryManager = Mock(RepositoryManager)
-      def repositoryApi = Mock(RepositoryApiImpl) {
-        getRepositoryManager() >> repositoryManager
-      }
       def mockRepo = Mock(Repository)
       def underTest = new OpenShiftConfigPlugin()
       underTest.repositoryManager = repositoryManager
-      underTest.repository = repositoryApi
 
     when:
       def result = underTest.filterExistingGroupRepositories(configMap)
@@ -192,12 +181,8 @@ class OpenShiftConfigPluginSpec extends Specification {
         getData() >> [recipe: 'MavenGroup']
       }
       def repositoryManager = Mock(RepositoryManager)
-      def repositoryApi = Mock(RepositoryApiImpl) {
-        getRepositoryManager() >> repositoryManager
-      }
       def underTest = new OpenShiftConfigPlugin()
       underTest.repositoryManager = repositoryManager
-      underTest.repository = repositoryApi
 
     when:
       def result = underTest.filterExistingGroupRepositories(configMap)

--- a/src/test/groovy/com/redhat/labs/nexus/openshift/RepositoryConfigWatcherSpec.groovy
+++ b/src/test/groovy/com/redhat/labs/nexus/openshift/RepositoryConfigWatcherSpec.groovy
@@ -22,6 +22,8 @@ package com.redhat.labs.nexus.openshift
 import io.kubernetes.client.models.V1ConfigMap
 import io.kubernetes.client.models.V1ObjectMeta
 import org.sonatype.nexus.blobstore.api.BlobStoreManager
+import org.sonatype.nexus.common.app.ApplicationVersion
+import org.sonatype.nexus.common.app.VersionComparator
 import org.sonatype.nexus.repository.Repository
 import org.sonatype.nexus.repository.config.Configuration
 import org.sonatype.nexus.repository.manager.RepositoryManager
@@ -30,6 +32,7 @@ import org.sonatype.nexus.repository.maven.VersionPolicy
 import org.sonatype.nexus.repository.storage.WritePolicy
 import org.sonatype.nexus.script.plugin.RepositoryApi
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class RepositoryConfigWatcherSpec extends Specification {
   def "test create maven hosted repository using all defaults"() {
@@ -41,9 +44,10 @@ class RepositoryConfigWatcherSpec extends Specification {
           recipe: 'MavenHosted'
       ] as Map<String, String>
       def underTest = new RepositoryConfigWatcher()
+      underTest.repositoryApi = repositoryApi
 
     when:
-      underTest.createNewRepository(repositoryApi, configMap)
+      underTest.createNewRepository(configMap)
 
     then:
       1 * configMap.getMetadata() >> metadata
@@ -54,23 +58,28 @@ class RepositoryConfigWatcherSpec extends Specification {
 
   def "test create docker hosted repository with httpPort 9080"() {
     given:
-    def repositoryApi = Mock(RepositoryApi)
-    def configMap = Mock(V1ConfigMap)
-    def metadata = Mock(V1ObjectMeta)
-    def data = [
-            recipe: 'DockerHosted',
-            httpPort: '9080'
-    ] as Map<String, String>
-    def underTest = new RepositoryConfigWatcher()
+      def repositoryApi = Mock(RepositoryApi)
+      def configMap = Mock(V1ConfigMap)
+      def metadata = Mock(V1ObjectMeta)
+      def applicationVersion = Mock(ApplicationVersion) {
+        getVersion() >> '3.17'
+      }
+      def data = [
+              recipe: 'DockerHosted',
+              httpPort: '9080'
+      ] as Map<String, String>
+      def underTest = new RepositoryConfigWatcher()
+      underTest.applicationVersion = applicationVersion
+      underTest.repositoryApi = repositoryApi
 
     when:
-    underTest.createNewRepository(repositoryApi, configMap)
+      underTest.createNewRepository(configMap)
 
     then:
-    1 * configMap.getMetadata() >> metadata
-    1 * metadata.getName() >> "testRepository"
-    8 * configMap.getData() >> data
-    1 * repositoryApi.createDockerHosted("testRepository", 9080, null, BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, true, WritePolicy.ALLOW, true)
+      1 * configMap.getMetadata() >> metadata
+      1 * metadata.getName() >> "testRepository"
+      8 * configMap.getData() >> data
+      1 * repositoryApi.createDockerHosted("testRepository", 9080, null, BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, true, WritePolicy.ALLOW, true)
   }
 
   def "test create docker proxy repository with httpPort 9081"() {
@@ -85,9 +94,10 @@ class RepositoryConfigWatcherSpec extends Specification {
               indexType: 'REGISTRY'
       ] as Map<String, String>
       def underTest = new RepositoryConfigWatcher()
+      underTest.repositoryApi = repositoryApi
 
     when:
-      underTest.createNewRepository(repositoryApi, configMap)
+      underTest.createNewRepository(configMap)
 
     then:
       1 * configMap.getMetadata() >> metadata
@@ -109,9 +119,10 @@ class RepositoryConfigWatcherSpec extends Specification {
               indexUrl: 'https://index.docker.io/'
       ] as Map<String, String>
       def underTest = new RepositoryConfigWatcher()
+      underTest.repositoryApi = repositoryApi
 
     when:
-      underTest.createNewRepository(repositoryApi, configMap)
+      underTest.createNewRepository(configMap)
 
     then:
       1 * configMap.getMetadata() >> metadata
@@ -130,14 +141,37 @@ class RepositoryConfigWatcherSpec extends Specification {
         getData() >> [members: 'repoA,repoB,repoC,repoD']
       }
       def underTest = new RepositoryConfigWatcher()
+      underTest.repositoryManager = repoManager
 
     when:
-      underTest.updateGroupMembers(repoManager, configMap)
+      underTest.updateGroupMembers(configMap)
 
     then:
       1 * repoManager.get('testGroup') >> repo
       2 * repo.getConfiguration() >> config
       1 * config.attributes >> [group: [memeberNames: 'repoA,repoB']]
       1 * repoManager.update(config)
+  }
+
+  @Unroll
+  def "Test filtering by version: #versionB >= #versionA == #isCompatible"() {
+    setup:
+      def appVersion = Mock(ApplicationVersion) {
+        getVersion() >> versionB
+      }
+      def mockEntry = Mock(Map.Entry) {
+        getValue() >> [version: versionA]
+      }
+      def underTest = new RepositoryConfigWatcher()
+      underTest.applicationVersion = appVersion
+
+    expect:
+      underTest.filterVersionedFields(mockEntry) == isCompatible
+
+    where:
+      versionA  | versionB    || isCompatible
+      '3.17'    | '3.14'      || false
+      '3.14'    | '3.17'      || true
+      '3.17'    | '3.17'      || true
   }
 }


### PR DESCRIPTION
Resolves #24 

This change allows for the plugin to run in older versions of Nexus (Back to ~3.8) and handle newly added fields gracefully.